### PR TITLE
Fix validCommand after removing 0b syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const board = new Board();
 
 function validCommand(command) {
   if (command.length !== 8) return false;
-  return [...command.slice(2)].every(d => d === '0' || d === '1');
+  return [...command].every(d => d === '0' || d === '1');
 }
 
 const users = {};


### PR DESCRIPTION
The `!led` command argument syntax changed from "`0b00000000`" to "`00000000`". The `slice` was there to remove the "`0b`" but it's no longer part of it. The first 2 characters were no longer being validated.